### PR TITLE
added lib.environment.spec.js to test for hasStore issue #46

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3733,14 +3733,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3749,6 +3741,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -7490,12 +7490,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -7531,6 +7525,12 @@
           }
         }
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3733,6 +3733,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3741,14 +3749,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -7490,6 +7490,12 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -7525,12 +7531,6 @@
           }
         }
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",

--- a/test/specs/lib.environment.spec.js
+++ b/test/specs/lib.environment.spec.js
@@ -1,0 +1,19 @@
+const { hasStore } = require('../../server/lib/environment.js');
+
+describe('hasStore', () => {
+  
+  test(`returns false when the DAV_ENV environment variable isn't set to 'simulated'`, () => {
+    expect.assertions(1);
+    if (process.env.DAV_ENV !== 'simulation') {
+      expect(hasStore).toBe(false);
+    }
+  });
+
+  test(`returns true when the DAV_ENV environment variable is set to 'simulated'`, () => {
+    expect.assertions();
+    if (process.env.DAV_ENV === 'simulation') {
+      expect(hasStore).toBe(true);
+    }
+  });
+  
+});

--- a/test/specs/lib.environment.spec.js
+++ b/test/specs/lib.environment.spec.js
@@ -7,13 +7,5 @@ describe('hasStore', () => {
     if (process.env.DAV_ENV !== 'simulation') {
       expect(hasStore).toBe(false);
     }
-  });
-
-  test(`returns true when the DAV_ENV environment variable is set to 'simulated'`, () => {
-    expect.assertions();
-    if (process.env.DAV_ENV === 'simulation') {
-      expect(hasStore).toBe(true);
-    }
-  });
-  
+  });  
 });


### PR DESCRIPTION
Hi @TalAter thanks for your patience, I had some initial trouble syncing my fork with upstream (had to delete index.lock several times).
Please review my PR, let me know if it requires any changes and also I wanted to ask you a quick question re: the second test
I used the test you suggested from your previous comment on issue [#46](https://github.com/DAVFoundation/missioncontrol/issues/46) (thanks again for explaining things in such detail, I appreciate it immensely 😄 `yourView.toBeTruthy()`=== GOLD )
To get the second test to pass for the opposite condition I had to remove the (1) in expect.assertions(1) which did not make a lot of sense to me... Is it possible it's just skipping that entire if statement and code block after it and that's why it's passing? In which case I should probably remove it if it's not doing anything? 
tryna close [#46](https://github.com/DAVFoundation/missioncontrol/issues/46)