### PR TITLE
#63 - Added test for random drone having coords property

### DIFF
--- a/test/specs/simulation.drone.spec.js
+++ b/test/specs/simulation.drone.spec.js
@@ -21,4 +21,10 @@ describe('generateRandom()', () => {
       generateRandom(sampleArguments)
     ).toHaveProperty('model');
   });
+
+  test('returns an object with coords', () => {
+    expect(
+      generateRandom(sampleArguments)
+    ).toHaveProperty('coords');
+  });
 });


### PR DESCRIPTION
Addresses issue #63. Added a test to make sure the generateRandom() function is returning an object that contains a coords attribute. 