### PR TITLE
added a test case for rating attribute in test/specs/simulation.drone.spec.js , closes #64

### DIFF
--- a/test/specs/simulation.drone.spec.js
+++ b/test/specs/simulation.drone.spec.js
@@ -37,7 +37,7 @@ describe('generateRandom()', () => {
   test('returns an object with a rating attribute', () => {
     expect(
       generateRandom(sampleArguments)
-    ).toHaveProperty('icon');
+    ).toHaveProperty('rating');
   });
 
   test('returns an object with a missions_completed_7_days attribute', () => {

--- a/test/specs/simulation.drone.spec.js
+++ b/test/specs/simulation.drone.spec.js
@@ -27,11 +27,17 @@ describe('generateRandom()', () => {
       generateRandom(sampleArguments)
     ).toHaveProperty('icon');
   });
-  
+
   test('returns an object with coords', () => {
     expect(
       generateRandom(sampleArguments)
     ).toHaveProperty('coords');
+  });
+
+  test('returns an object with a rating attribute', () => {
+    expect(
+      generateRandom(sampleArguments)
+    ).toHaveProperty('icon');
   });
 
   test('returns an object with a missions_completed_7_days attribute', () => {


### PR DESCRIPTION
Hi, 
I added a test case that checks if the drone generated by the generateRandom function has a "rating" property. Should take care of issue #64. Passes npm test.

Also, quick note for other first timers who may end up confused- one of the test cases in DavIdIcon fails if you are on node 6 instead of node 8. Updating to node 8 takes care of the failing test. 