### PR TITLE
#65 Add tests to check missions_completed attribute in random drone generator

### DIFF
--- a/test/specs/simulation.drone.spec.js
+++ b/test/specs/simulation.drone.spec.js
@@ -40,6 +40,12 @@ describe('generateRandom()', () => {
     ).toHaveProperty('rating');
   });
 
+  test('returns an object with a missions_completed attribute', () => {
+    expect(
+      generateRandom(sampleArguments)
+    ).toHaveProperty('missions_completed');
+  });
+
   test('returns an object with a missions_completed_7_days attribute', () => {
     expect(
       generateRandom(sampleArguments)


### PR DESCRIPTION
…ator

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a test that checks missions_completed attribute following the coding style of the other tests. I ran `npm test` and it ran without errors. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#65 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Completes the tests required for random drone generator.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using sample arguments, we call generateRandom passing these arguments and see if the specified tests pass. If one of them fails, then that specific error message will show and the other tests will continue to run regardless of one of them failing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
