### PR TITLE
Issue #96. Test the url getDavIdIconUrl(davId)

### DIFF
--- a/test/specs/lib.davIdIcon.spec.js
+++ b/test/specs/lib.davIdIcon.spec.js
@@ -18,17 +18,10 @@ describe('getDavIdIconUrl()', () => {
     }
   };
 
-  test('Return contains the davID within it options',() => {     
-    expect(       
-      checkIfReturnDavId(getDavIdIconUrl(dummyDavId))     
-    ).toBeTruthy();   
-  });    
+  test('returns a string containing the given davID', () => {
+    expect(
+      getDavIdIconUrl(dummyDavId).includes(dummyDavId)
+    ).toBeTruthy();
+  });  
   
-  const checkIfReturnDavId = (url) => {     
-    if (url.toLowerCase().indexOf(dummyDavId) >= 0) {       
-      return true;     
-    } else {       
-      return false;     
-    }   
-  }
 });

--- a/test/specs/lib.davIdIcon.spec.js
+++ b/test/specs/lib.davIdIcon.spec.js
@@ -17,4 +17,18 @@ describe('getDavIdIconUrl()', () => {
       return false;  
     }
   };
+
+  test('Return contains the davID within it options',() => {     
+    expect(       
+      checkIfReturnDavId(getDavIdIconUrl(dummyDavId))     
+    ).toBeTruthy();   
+  });    
+  
+  const checkIfReturnDavId = (url) => {     
+    if (url.toLowerCase().indexOf(dummyDavId) >= 0) {       
+      return true;     
+    } else {       
+      return false;     
+    }   
+  }
 });


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
Test whether the url getDavIdIconUrl(davId) returns contains the davId using the indexOf method (on the URL that is returned from the function).
## Description
<!--- Describe your changes in detail -->

I added the function "checkIfReturnDavId" that takes the parameter of the url returned from the method "getDavIdIconUrl". It will return false if there is no DavId in the URL, and it will return true if there is the DavId in the URL. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/DAVFoundation/missioncontrol/issues/96

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solved the issue that is mentioned.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I used "npm test". All 5 files passed.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
