### PR TITLE
feat: added mission_command route

### DIFF
--- a/server/controllers/MissionController.js
+++ b/server/controllers/MissionController.js
@@ -8,7 +8,7 @@ const command = async (req, res) => {
   const mission = await getMission(mission_id);
   const vehicle = await getVehicle(mission.vehicle_id);
 
-  if (user_id !== mission.user_id) res.sendStatus(401);
+  if (user_id !== mission.user_id) return res.sendStatus(401);
 
   if (command === 'takeoff_pickup' && vehicle.status === 'waiting_pickup'){
     await updateMission(mission_id, {'takeoff_pickup_at': Date.now()});

--- a/server/controllers/MissionController.js
+++ b/server/controllers/MissionController.js
@@ -8,6 +8,8 @@ const command = async (req, res) => {
   const mission = await getMission(mission_id);
   const vehicle = await getVehicle(mission.vehicle_id);
 
+  if (user_id !== mission.user_id) res.sendStatus(401);
+
   if (command === 'takeoff_pickup' && vehicle.status === 'waiting_pickup'){
     await updateMission(mission_id, {'takeoff_pickup_at': Date.now()});
     await createMissionUpdate(mission_id, 'takeoff_pickup');
@@ -15,6 +17,6 @@ const command = async (req, res) => {
   }
 
   res.json({vehicle, mission});
-}
+};
 
 module.exports = { command };

--- a/server/controllers/MissionController.js
+++ b/server/controllers/MissionController.js
@@ -1,0 +1,20 @@
+const { getMission, updateMission } = require('../store/missions');
+const { createMissionUpdate } = require('../store/mission_updates');
+const { getVehicle, updateVehicleStatus } = require('../store/vehicles');
+
+
+const command = async (req, res) => {
+  const { user_id, mission_id, command} = req.query;
+  const mission = await getMission(mission_id);
+  const vehicle = await getVehicle(mission.vehicle_id);
+
+  if (command === 'takeoff_pickup' && vehicle.status === 'waiting_pickup'){
+    await updateMission(mission_id, {'takeoff_pickup_at': Date.now()});
+    await createMissionUpdate(mission_id, 'takeoff_pickup');
+    await updateVehicleStatus(mission.vehicle_id, 'takeoff_pickup');
+  }
+
+  res.json({vehicle, mission});
+}
+
+module.exports = { command };

--- a/server/server-web.js
+++ b/server/server-web.js
@@ -3,6 +3,7 @@ const getOrCreateUser = require('./middleware/getOrCreateUser');
 
 const StatusController = require('./controllers/StatusController');
 const RequestController = require('./controllers/RequestController');
+const MissionController = require('./controllers/MissionController');
 
 // Create thrift connection to Captain
 require('./client-thrift').start({
@@ -22,6 +23,8 @@ app.get('/status', StatusController.getStatus);
 app.get('/request/new', RequestController.newRequest);
 app.get('/request/cancel', RequestController.cancelRequest);
 app.get('/choose_bid', RequestController.chooseBid);
+
+app.get('/mission_command', MissionController.command)
 
 module.exports = {
   start: () => {

--- a/server/server-web.js
+++ b/server/server-web.js
@@ -24,7 +24,7 @@ app.get('/request/new', RequestController.newRequest);
 app.get('/request/cancel', RequestController.cancelRequest);
 app.get('/choose_bid', RequestController.chooseBid);
 
-app.get('/mission_command', MissionController.command)
+app.get('/mission_command', MissionController.command);
 
 module.exports = {
   start: () => {

--- a/server/simulation/missionProgress.js
+++ b/server/simulation/missionProgress.js
@@ -19,7 +19,7 @@ module.exports = [
     },
   },
   {
-    status: 'waiting_pickup',
+    status: 'takeoff_pickup',
     nextVehicleStatus: 'travelling_dropoff',
     nextMissionStatus: 'travelling_dropoff',
     conditionForNextStatus: mission => {


### PR DESCRIPTION
## Description
- Added a new route that will accept a `user id`, a `mission id`, and a command.

- If `user_id` doesn't match the mission's user_id, it returns a 401.

- If the `command` string is `takeoff_pickup` and the current status of the vehicle is `waiting_pickup`, it updates the mission and vehicle status to `takeoff_pickup`.

- Also fixed `missionProgress.js`. The fix stops the mission/vehicle status from moving from `waiting_pickup` to `travelling_droppoff` automatically without any user input/command.