### PR TITLE
Added mission_id to getMission() and made a getLatestMission() method. #130

### DIFF
--- a/server/controllers/StatusController.js
+++ b/server/controllers/StatusController.js
@@ -1,6 +1,6 @@
 const { getVehiclesInRange, updateVehicleStatus, getVehicle, getVehicles } = require('../store/vehicles');
 const { getBidsForRequest } = require('../store/bids');
-const { getLatestMissionId, getMission, updateMission } = require('../store/missions');
+const { getLatestMission, updateMission } = require('../store/missions');
 const { createMissionUpdate } = require('../store/mission_updates');
 const { hasStore } = require('../lib/environment');
 const missionProgress = require('../simulation/missionProgress');
@@ -8,8 +8,7 @@ const missionProgress = require('../simulation/missionProgress');
 const getStatus = async (req, res) => {
   const { lat, long, requestId, user_id } = req.query;
   const status = 'idle';
-  const latestMissionId = await getLatestMissionId(user_id);
-  const latestMission = await getMission(latestMissionId);
+  const latestMission = await getLatestMission(user_id);
   const bids = (!hasStore() || !requestId) ? [] : await getBidsForRequest(requestId);
   let vehicles = [];
   if (hasStore()) {
@@ -29,9 +28,9 @@ const getStatus = async (req, res) => {
       let elapsedTime = Date.now() - latestMission.user_signed_at;
       let elapsedSeconds = ((elapsedTime % 60000) / 1000).toFixed(0);
       if (elapsedSeconds > 6) {
-        await updateMission(latestMissionId, {'vehicle_signed_at': Date.now(), 'status': 'in_progress'});
+        await updateMission(latestMission.mission_id, {'vehicle_signed_at': Date.now(), 'status': 'in_progress'});
         await updateVehicleStatus(latestMission.vehicle_id, 'travelling_pickup');
-        await createMissionUpdate(latestMissionId, 'travelling_pickup');
+        await createMissionUpdate(latestMission.mission_id, 'travelling_pickup');
       }
       res.json({status, vehicles, bids});
       break;
@@ -45,8 +44,8 @@ const getStatus = async (req, res) => {
         const timestampString = currentStatus.nextMissionStatus + '_at';
         let timestampObject = {};
         timestampObject[timestampString] = Date.now();
-        await updateMission(latestMissionId, timestampObject);
-        await createMissionUpdate(latestMissionId, currentStatus.nextMissionStatus);
+        await updateMission(latestMission.mission_id, timestampObject);
+        await createMissionUpdate(latestMission.mission_id, currentStatus.nextMissionStatus);
         await updateVehicleStatus(latestMission.vehicle_id, currentStatus.nextVehicleStatus);
       }
       vehicles = [vehicle];

--- a/server/store/missions.js
+++ b/server/store/missions.js
@@ -4,14 +4,20 @@ const { getRequest } = require('./requests');
 const { createMissionUpdate } = require('./mission_updates');
 
 const getMission = async missionId => {
-  return await redis.hgetallAsync(`missions:${missionId}`);
+  const mission = await redis.hgetallAsync(`missions:${missionId}`);
+  mission.mission_id = missionId;
+  return mission;
 };
 
-const getLatestMissionId = async userId => {
-  // use zrevrange to reverse sorted set from highest to lowest
-  // reversed values will put most recent timestamp at the top
+const getLatestMission = async userId => {
   const missions = await redis.zrevrangeAsync(`user_missions:${userId}`, 0, -1);
-  return missions[0];
+  let mission = null;
+  if (missions.length > 0) {
+    mission = await getMission(missions[0]); 
+    if (typeof mission === 'object') {
+      return mission;
+    }
+  }
 };
 
 const updateMission = async (id, params) => {
@@ -76,6 +82,6 @@ const createMission = async ({ user_id, bid_id }) => {
 module.exports = {
   createMission,
   getMission,
-  getLatestMissionId,
+  getLatestMission,
   updateMission,
 };


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added mission_id assignment to mission object in getMission(). I created a getLatestMission() method in the missions store. This method returns an object that contains both the latest mission id and the latest mission. I then refactored the calls to the latestMissionId variable in StatusController.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#130
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
By adding the mission_id to the latestMission object it makes the StatusController a little more concise and easy to read.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm test` passed and the output of the object is accurate.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
