### PR TITLE
added makefile to facilitate development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+all:
+	pass
+
+up:
+	docker-compose build && docker-compose up &
+
+down:
+	docker-compose down
+
+flush:
+	docker exec -it missioncontrol_redis_1 redis-cli FLUSHALL
+
+log:
+	docker logs missioncontrol_missioncontrol_1 -f


### PR DESCRIPTION
Added makefile to facilitate development

## Description
Makefile allows starting, stopping, flushing Redis state and viewing logs.
Makes it easier to perform these operations.
Requires make tool. (Usually bundled with all linux based OSs)