### PR TITLE
issue #156 - Added the function setBidTTL(bidId) to replace repeated …

### DIFF
--- a/server/store/bids.js
+++ b/server/store/bids.js
@@ -23,13 +23,13 @@ const saveBid = async ({ vehicle_id, price, time_to_pickup, time_to_dropoff }, n
   );
 
   // Set TTL for bid
-  redis.expire(`bids:${bidId}`, config('bids_ttl'));
+  setBidTTL(bidId);
   return bidId;
 };
 
 const getBid = async bidId => {
   // Set TTL for bid
-  redis.expire(`bids:${bidId}`, config('bids_ttl'));
+  setBidTTL(bidId);
   return await redis.hgetallAsync(`bids:${bidId}`);
 };
 
@@ -44,7 +44,7 @@ const getBidsForNeed = async needId => {
   const bidIds = await redis.lrangeAsync(`need_bids:${needId}`, 0, -1);
   const bids = await Promise.all(
     bidIds.map(bidId => {
-      redis.expire(`bids:${bidId}`, config('bids_ttl'));
+      setBidTTL(bidId);
       return redis.hgetallAsync(`bids:${bidId}`);
     }),
   );
@@ -91,3 +91,5 @@ module.exports = {
   getBid,
   deleteBidsForNeed,
 };
+
+const setBidTTL = async bidId => redis.expire(`bids:${bidId}`, config('bids_ttl'));

--- a/server/store/bids.js
+++ b/server/store/bids.js
@@ -92,4 +92,4 @@ module.exports = {
   deleteBidsForNeed,
 };
 
-const setBidTTL = async bidId => redis.expire(`bids:${bidId}`, config('bids_ttl'));
+const setBidTTL = bidId => redis.expire(`bids:${bidId}`, config('bids_ttl'));


### PR DESCRIPTION
## Description
I changed `redis.expire(`bids:${bidId}`, config('bids_ttl'));` to `setBidTTL(bidId)` and I create the function to solve the repeated code.

## Related Issue
#156 