### PR TITLE
issue #154 - Added unit test for price-distance relationship in randomBid()

### DIFF
--- a/test/specs/simulation.vehicles.spec.js
+++ b/test/specs/simulation.vehicles.spec.js
@@ -42,4 +42,17 @@ describe('randomBid()', () => {
       typeof bid.time_to_dropoff
     ).toBe('number');
   });
+
+  test('returns a price proportional to the total distance travelled', () => {
+    const origin = randomCoords(sampleArguments);
+    const bidShort = randomBid(origin, {lat: origin.lat + 0.05, long: origin.long}, {lat: origin.lat + 0.10, long: origin.long});
+    
+    expect(
+      bidShort.price
+    ).toBeLessThan(randomBid(origin, {lat: origin.lat + 0.05, long: origin.long}, {lat: origin.lat + 0.15, long: origin.long}).price);
+
+    expect(
+      bidShort.price
+    ).toBeLessThan(randomBid(origin, {lat: origin.lat + 0.10, long: origin.long}, {lat: origin.lat + 0.15, long: origin.long}).price);
+  });
 });

--- a/test/specs/simulation.vehicles.spec.js
+++ b/test/specs/simulation.vehicles.spec.js
@@ -43,7 +43,7 @@ describe('randomBid()', () => {
     ).toBe('number');
   });
 
-  test('returns a price proportional to the total distance travelled', () => {
+  test('returns a price that is influenced by the total distance travelled', () => {
     const origin = randomCoords(sampleArguments);
     const bidShort = randomBid(origin, {lat: origin.lat + 0.05, long: origin.long}, {lat: origin.lat + 0.10, long: origin.long});
     


### PR DESCRIPTION
Added test checking both cases of having longer origin-pickup and pickup-dropoff distances in order to verify that the generated prices from randomBid() are proportional to the total distance travelled. 