### PR TITLE
Changed License from ISC to MIT in k8s/package.json

### DIFF
--- a/k8s/package.json
+++ b/k8s/package.json
@@ -2,7 +2,7 @@
   "name": "k8s",
   "version": "1.0.0",
   "description": "",
-  "license": "ISC",
+  "license": "MIT",
   "author": "",
   "main": "getVersion.js",
   "directories": {},


### PR DESCRIPTION
Hi TalAter, 

I just made the license change in the k8s/package.json from ISC to MIT.

Kindly look into my PR and judge accordingly.

Kind regards,
Waheed
Open Source is the Deal
