### PR TITLE
Fixed issue #203 

### DIFF
--- a/k8s/package.json
+++ b/k8s/package.json
@@ -2,7 +2,7 @@
   "name": "k8s",
   "version": "1.0.0",
   "description": "",
-  "license": "ISC",
+  "license": "MIT",
   "author": "",
   "main": "getVersion.js",
   "directories": {},


### PR DESCRIPTION
Corrected license name to MIT in package.json file in k8s directory.