### PR TITLE
Add test for connected Cassandra status to be on 'localhost' 

### DIFF
--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -91,6 +91,11 @@ describe('App', () => {
       const res = await chai.request(app).get('/health');
       expect(res.body.message.kafka.connected).to.eql(true);
     });
+
+    it('should have "localhost" as address of the single host in the Cassandra status message', async () => {
+      const res = await chai.request(app).get('/health');
+      expect(res.body.message.cassandra.hosts).to.have.nested.property('[0].address', 'localhost');
+    });
   });
   describe('status (failure)', () => {
     let app: Application;


### PR DESCRIPTION
Test for connected Cassandra status to have 'localhost' address of the first entry of the host list