### PR TITLE
Fix Travis CI build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "ts-jest": "^23.0.1",
     "ts-node": "^7.0.0",
     "tslint": "^5.11.0",
-    "typescript": "^2.9.2"
+    "typescript": "^3.3.3333"
   }
 }

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -16,7 +16,7 @@ const kafkaMock = {
   createTopic: jest.fn(() => Promise.resolve()),
   sendMessage: jest.fn(() => Promise.resolve()),
   sendPayloads: jest.fn(() => Promise.resolve()),
-  rawMessages: jest.fn(() => Promise.resolve()),
+  rawMessages: jest.fn().mockResolvedValue(null),
   isConnected: jest.fn(() => Promise.resolve(true)),
 };
 
@@ -24,7 +24,7 @@ const kafkaFailingToConnectMock = {
   createTopic: jest.fn(() => Promise.resolve()),
   sendMessage: jest.fn(() => Promise.resolve()),
   sendPayloads: jest.fn(() => Promise.resolve()),
-  rawMessages: jest.fn(() => Promise.resolve()),
+  rawMessages: jest.fn().mockResolvedValue(null),
   isConnected: () => {
     throw new Error('No Kafka, sorry');
   },
@@ -260,7 +260,7 @@ describe('App', () => {
             highWaterOffset: 1,
           },
         ]);
-        kafkaMock.rawMessages.mockResolvedValue(messages);
+        kafkaMock.rawMessages = jest.fn().mockResolvedValue(messages);
         const app = (await import('./App')).default;
         const res = await chai
           .request(app)
@@ -295,7 +295,7 @@ describe('App', () => {
           highWaterOffset: 2,
         };
         const messages = Observable.from([firstMessage, secondMessage]);
-        kafkaMock.rawMessages.mockResolvedValue(messages);
+        kafkaMock.rawMessages = jest.fn().mockResolvedValue(messages);
 
         const app = (await import('./App')).default;
         const res = await chai
@@ -314,7 +314,7 @@ describe('App', () => {
 
       it('should get timeout due to empty topic', async () => {
         const messages = Observable.from([]);
-        kafkaMock.rawMessages.mockResolvedValue(messages);
+        kafkaMock.rawMessages = jest.fn().mockResolvedValue(messages);
         const app = (await import('./App')).default;
         const res = await chai
           .request(app)


### PR DESCRIPTION
Travis was failing with 2 different errors. The first one is fixed by initializing jest.fn() exactly as in the [documentation](https://jestjs.io/docs/en/mock-function-api.html#mockfnmockresolvedvaluevalue). Second error revealed itself only after the first was fixed. The solution (upgrade to 3.3.3333) is borrowed from https://travis-ci.community/t/node-modules-types-jest-index-d-ts31-error-ts2370-a-rest-parameter-must-be-of-an-array-type/2149/2.